### PR TITLE
Add cache dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 artifacts/
 .env
+.ruff_cache/
+.pytest_cache/
+__pycache__/


### PR DESCRIPTION
## Summary
- ignore `.ruff_cache/`, `.pytest_cache/`, and `__pycache__/` build artifacts

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c004544e083309c72e00161c97c1d