### PR TITLE
Add tests workflow and doc install step

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,21 @@
+name: Testes
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest -q

--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ Este script (antigo `esaj_datajud_connector.py`) é **enxuto** e serve somente p
 
 1. Crie um *branch* a partir de `main`.
 2. Siga o padrão *Black* (`black .`).
-3. Adicione/atualize *tests* (`python jurimetria_pipeline.py test`).
-4. Abra um *pull request*.
+3. Instale as dependências antes de rodar os testes:
+   `pip install -r requirements.txt`
+4. Adicione/atualize *tests* (`python jurimetria_pipeline.py test`).
+5. Abra um *pull request*.
 
 ---
 


### PR DESCRIPTION
## Summary
- mention installing dependencies before running tests in README
- add GitHub Actions workflow to run tests with dependencies installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685bfb730efc8330b1113fe258cb037a