### PR TITLE
Fix README paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Bem-vindo! Este repositório oferece **um fluxo oficial completo** para baixar, tratar e analisar dados judiciais via API pública do CNJ, além de **um conector opcional** para cenários específicos de integração.
 
-## Fluxo oficial: `jurimetria_pipeline.py`
+## Fluxo oficial: `src/jurimetria_pipeline.py`
 
 | Etapa          | O que faz                                                                                     | Saída                     |
 |----------------|----------------------------------------------------------------------------------------------|---------------------------|
@@ -17,15 +17,15 @@ Bem-vindo! Este repositório oferece **um fluxo oficial completo** para baixar, 
 export CNJ_API_KEY='APIKey …'
 
 # Coletar apenas TJCE (padrão):
-python jurimetria_pipeline.py
+python src/jurimetria_pipeline.py
 
 # Coletar múltiplos tribunais (ex.: TJSP, TJRS):
-python jurimetria_pipeline.py TJSP TJRS
+python src/jurimetria_pipeline.py TJSP TJRS
 ```
 
 ---
 
-## 🔌 Conector opcional: `legacy_esaj_connector.py`
+## 🔌 Conector opcional: `legacy/legacy_datajud_connector.py`
 
 Este script (antigo `esaj_datajud_connector.py`) é **enxuto** e serve somente para **baixar os documentos “crus”** da API ESAJ sem qualquer pós‑processamento. Útil quando você quer:
 
@@ -33,7 +33,7 @@ Este script (antigo `esaj_datajud_connector.py`) é **enxuto** e serve somente p
 * Integrar a coleta a um *pipeline* externo (Airflow, cron, etc.).
 * Explorar outros formatos de saída com scripts próprios.
 
-> Se você **não** precisa desses casos, basta usar o `jurimetria_pipeline.py` e ignorar o conector.
+> Se você **não** precisa desses casos, basta usar o `src/jurimetria_pipeline.py` e ignorar o conector.
 
 ---
 
@@ -41,10 +41,14 @@ Este script (antigo `esaj_datajud_connector.py`) é **enxuto** e serve somente p
 
 ```
 .
-├── jurimetria_pipeline.py        # Fluxo oficial (coleta → análises)
-├── legacy_esaj_connector.py      # Conector opcional (download puro)
-├── dados_jurimetria/             # Saídas (criado em tempo de execução)
-└── README.md                     # Este arquivo
+├── src/
+│   └── jurimetria_pipeline.py        # Fluxo oficial (coleta → análises)
+├── legacy/
+│   └── legacy_datajud_connector.py   # Conector opcional (download puro)
+├── tests/
+│   └── test_anpp_pipeline.py         # Testes unitários
+├── dados_jurimetria/                 # Saídas (criado em tempo de execução)
+└── README.md                         # Este arquivo
 ```
 
 ---
@@ -53,7 +57,7 @@ Este script (antigo `esaj_datajud_connector.py`) é **enxuto** e serve somente p
 
 1. Crie um *branch* a partir de `main`.
 2. Siga o padrão *Black* (`black .`).
-3. Adicione/atualize *tests* (`python jurimetria_pipeline.py test`).
+3. Adicione/atualize *tests* (`python src/jurimetria_pipeline.py test`).
 4. Abra um *pull request*.
 
 ---


### PR DESCRIPTION
## Summary
- update README to show correct repo structure
- fix usage examples and contributor instructions

## Testing
- `python src/jurimetria_pipeline.py test` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685bfb71003483308ef7685a560b48c6