### PR TITLE
Fix CLI save option and cleanup workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,28 +1,20 @@
-diff --git a//dev/null b/.github/workflows/tests.yml
-index 0000000000000000000000000000000000000000..b7dcbccf166e88ea6db1da058c3e84a0e82f4b14 100644
---- a//dev/null
-+++ b/.github/workflows/tests.yml
-@@ -0,0 +1,21 @@
-+name: Testes
-+
-+on:
-+  push:
-+    branches: [main]
-+  pull_request:
-+
-+jobs:
-+  test:
-+    runs-on: ubuntu-latest
-+
-+    steps:
-+      - uses: actions/checkout@v4
-+      - uses: actions/setup-python@v5
-+        with:
-+          python-version: '3.11'
-+          cache: 'pip'
-+      - - name: Install dependencies
-  run: pip install -r requirements.txt
-- name: Install pytest
-  run: pip install pytest
-- name: Run pytest
-  run: pytest -q
+name: Testes
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest -q

--- a/legacy/legacy_datajud_connector.py
+++ b/legacy/legacy_datajud_connector.py
@@ -178,11 +178,13 @@ def cli() -> None:
     s1.add_argument("--data-inicio", default="2024-01-01")
     s1.add_argument("--data-fim")
     s1.add_argument("--max-pages", type=int)
+    s1.add_argument("--save", metavar="PATH")
 
     s2 = sub.add_parser("datajud", help="Estatísticas DataJud")
     s2.add_argument("--classe", required=True)
     s2.add_argument("--ano", type=int, required=True)
     s2.add_argument("--metrica", choices=["tempo_julgamento", "taxa_provimento"], default="tempo_julgamento")
+    s2.add_argument("--save", metavar="PATH")
 
     args = parser.parse_args()
 
@@ -193,10 +195,20 @@ def cli() -> None:
             data_fim=args.data_fim,
             max_pages=args.max_pages,
         )
-        print(json.dumps(res, ensure_ascii=False, indent=2))
+        out = json.dumps(res, ensure_ascii=False, indent=2)
+        if args.save:
+            with open(args.save, "w", encoding="utf-8") as f:
+                f.write(out)
+        else:
+            print(out)
     elif args.cmd == "datajud":
         res = fetch_datajud_tjce(args.classe, args.ano, args.metrica)
-        print(json.dumps(res, ensure_ascii=False, indent=2))
+        out = json.dumps(res, ensure_ascii=False, indent=2)
+        if args.save:
+            with open(args.save, "w", encoding="utf-8") as f:
+                f.write(out)
+        else:
+            print(out)
 
 if __name__ == "__main__":
     cli()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 tqdm
 pytest
 matplotlib
+pyarrow

--- a/tests/test_legacy_connector.py
+++ b/tests/test_legacy_connector.py
@@ -1,0 +1,37 @@
+import json
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+import tempfile
+
+# allow import of legacy_datajud_connector.py
+sys.path.append(str(Path(__file__).resolve().parents[1] / "legacy"))
+import legacy_datajud_connector as ldc
+
+
+class TestCLI(unittest.TestCase):
+    def test_save_option(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out = Path(tmpdir) / "out.json"
+            sample = [{"ok": True}]
+            with mock.patch(
+                "legacy_datajud_connector.fetch_esaj_tjce", return_value=sample
+            ):
+                test_args = [
+                    "ldc",
+                    "esaj",
+                    "--classe",
+                    "A",
+                    "--save",
+                    str(out),
+                ]
+                with mock.patch.object(sys, "argv", test_args):
+                    ldc.cli()
+            self.assertTrue(out.exists())
+            data = json.loads(out.read_text())
+            self.assertEqual(data, sample)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- support `--save` in `legacy_datajud_connector.py`
- test saving behavior with a new unit test
- repair the GitHub Actions tests workflow
- include `pyarrow` for Parquet support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_685c0b488a008330a6ec77961f49e30f